### PR TITLE
Everything but the xcc tests

### DIFF
--- a/oasis-macros/Cargo.toml
+++ b/oasis-macros/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["oasis", "blockchain", "heavy magic"]
 
 [dependencies]
 proc-macro2 = "0.4"
-quote = "0.6"
+proc-quote = "0.2"
 syn = { version = "0.15", features = ["full", "extra-traits", "visit-mut"] }
 tiny-keccak = "1.4"
 

--- a/oasis-macros/src/lib.rs
+++ b/oasis-macros/src/lib.rs
@@ -8,7 +8,7 @@
 
 extern crate proc_macro;
 #[macro_use]
-extern crate quote;
+extern crate proc_quote;
 #[macro_use]
 extern crate syn;
 

--- a/oasis-macros/src/utils.rs
+++ b/oasis-macros/src/utils.rs
@@ -57,3 +57,9 @@ impl syn::visit_mut::VisitMut for Deborrower {
         syn::visit_mut::visit_type_mut(self, ty);
     }
 }
+
+macro_rules! format_ident {
+    ($fmt_str:literal, $($fmt_arg:expr),+) => {
+        syn::Ident::new(&format!($fmt_str, $($fmt_arg),+), proc_macro2::Span::call_site())
+    }
+}

--- a/oasis-std/src/build.rs
+++ b/oasis-std/src/build.rs
@@ -1,0 +1,26 @@
+use std::io::Write as _;
+
+pub fn build_contract() -> Result<(), failure::Error> {
+    let output = std::process::Command::new("cargo")
+        .args(&["build", "--target=wasm32-unknown-unknown", "--release"])
+        .args(&["--target-dir", "target/contract"])
+        .args(&["--features", "deploy"])
+        .output()?;
+
+    let crate_name = std::env::var("CARGO_PKG_NAME")?;
+    let lib_name = crate_name.replace("-", "_");
+
+    if !output.status.success() {
+        std::fs::write(format!("target/contract/{}.wasm", lib_name), "")?;
+        std::io::stderr().write_all(&output.stderr)?;
+        return Ok(());
+    }
+
+    std::process::Command::new("wasm-build")
+        .args(&["target/contract", &lib_name])
+        .args(&["--target", "wasm32-unknown-unknown"])
+        .args(&["--final", &crate_name])
+        .output()?;
+
+    Ok(())
+}

--- a/oasis-std/src/lib.rs
+++ b/oasis-std/src/lib.rs
@@ -10,6 +10,7 @@ extern crate serde;
 #[macro_use]
 extern crate uint;
 
+pub mod build;
 pub mod errors;
 pub mod exe;
 pub mod ext;
@@ -23,4 +24,5 @@ pub mod prelude {
     pub use macros::{contract, Contract};
 }
 
+pub use build::build_contract;
 pub use macros::contract;

--- a/oasis-test/src/lib.rs
+++ b/oasis-test/src/lib.rs
@@ -6,5 +6,7 @@ pub use ext::{
 
 #[macro_export]
 macro_rules! init {
-    () => {};
+    () => {
+        use oasis_std::prelude::*;
+    };
 }


### PR DESCRIPTION
This PR is all of the improvements and bugfixes that were for xcc tests but before we decided that language-specific integration tests weren't happening.

The only real addition here is `fn build_contract` which supports the production `fn new` that creates a new contract (using `ext::create`).