### PR TITLE
Minimize dependencies

### DIFF
--- a/oasis-macros/src/event_derive.rs
+++ b/oasis-macros/src/event_derive.rs
@@ -45,6 +45,7 @@ pub fn event_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(quote! {
         mod #impl_wrapper_ident {
             use super::*;
+            use oasis_std::reexports::*;
 
             #[derive(Default)]
             pub struct #topics_struct_ident {

--- a/oasis-macros/src/service_attr.rs
+++ b/oasis-macros/src/service_attr.rs
@@ -30,6 +30,7 @@ pub fn service(
         extern crate serde;
 
         use oasis_std::prelude::*;
+        use oasis_std::reexports::*;
     };
 
     macro_rules! early_return {

--- a/oasis-std/Cargo.toml
+++ b/oasis-std/Cargo.toml
@@ -15,6 +15,7 @@ oasis-macros = { version = "0.1", path = "../oasis-macros" }
 oasis-types = { version = "0.1", path = "../oasis-types" }
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.9"
+tiny-keccak = "1.4"
 
 [dev-dependencies]
 oasis-test = { path = "../oasis-test" }

--- a/oasis-std/src/errors.rs
+++ b/oasis-std/src/errors.rs
@@ -1,3 +1,5 @@
+use failure::Fail;
+
 pub type Result<T> = std::result::Result<T, failure::Error>;
 
 #[derive(Fail, Debug)]

--- a/oasis-std/src/lib.rs
+++ b/oasis-std/src/lib.rs
@@ -1,7 +1,5 @@
 #![feature(linkage, trait_alias)]
 
-#[macro_use]
-extern crate failure;
 pub extern crate oasis_macros as macros;
 
 pub mod build;
@@ -17,6 +15,13 @@ include!("alloc.rs");
 pub mod prelude {
     pub use crate::{errors::*, exe::*, ext as oasis, types::*};
     pub use macros::{service, Event, Service};
+}
+
+pub mod reexports {
+    pub use failure;
+    pub use serde;
+    pub use serde_cbor;
+    pub use tiny_keccak;
 }
 
 pub use build::build_service;

--- a/tests/idl_gen/Cargo.toml
+++ b/tests/idl_gen/Cargo.toml
@@ -8,15 +8,13 @@ edition = "2018"
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
-failure = "0.1"
 oasis-std = { path = "../../oasis-std" }
 serde = { version = "1.0", features = ["derive"] }
-serde_cbor = "0.9"
 testlib = { path = "../testlib" }
-tiny-keccak = "1.4"
 
 [dev-dependencies]
 oasis-test = { path = "../../oasis-test" }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [build-dependencies]

--- a/tests/testlib/Cargo.toml
+++ b/tests/testlib/Cargo.toml
@@ -7,5 +7,3 @@ edition = "2018"
 [dependencies]
 oasis-std = { path = "../../oasis-std" }
 serde = { version = "1.0", features = ["derive"] }
-serde_cbor = "0.9"
-tiny-keccak = "1.4"

--- a/tests/xcc-a/Cargo.toml
+++ b/tests/xcc-a/Cargo.toml
@@ -8,11 +8,8 @@ edition = "2018"
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
-failure = "0.1"
 oasis-std = { path = "../../oasis-std" }
 serde = { version = "1.0", features = ["derive"] }
-serde_cbor = "0.9"
-tiny-keccak = "1.4"
 xcc-b = { path = "../xcc-b" }
 
 [dev-dependencies]

--- a/tests/xcc-b/Cargo.toml
+++ b/tests/xcc-b/Cargo.toml
@@ -8,11 +8,8 @@ edition = "2018"
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
-failure = "0.1"
 oasis-std = { path = "../../oasis-std" }
 serde = { version = "1.0", features = ["derive"] }
-serde_cbor = "0.9"
-tiny-keccak = "1.4"
 
 [dev-dependencies]
 oasis-test = { path = "../../oasis-test" }


### PR DESCRIPTION
Resolves #85 as best as possible. It's not possible to re-export serde since the derive isn't re-exported. That's okay, though, because `derive(Serialize, Deserialize)` is ubiquitous and will be needed for all but the most trivial service definitions.

```
error[E0658]: The attribute `serde` is currently unknown to the compiler and may have meaning added to it in the future
 --> /oasis/Projects/platform/oasis-rs/tests/xcc-b/src/lib.rs:2:1
  |
2 | #[oasis_std::service]
  | ^^^^^^^^^^^^^^^^^^^^^
...

error[E0277]: the trait bound `service::RpcPayload: oasis_std::reexports::serde::Deserialize<'_>` is not satisfied
 --> /oasis/Projects/platform/oasis-rs/tests/xcc-b/src/lib.rs:2:1
  |
2 | #[oasis_std::service]
  | ^^^^^^^^^^^^^^^^^^^^^ the trait `oasis_std::reexports::serde::Deserialize<'_>` is not implemented for `service::RpcPayload`
```