### PR TITLE
Update examples for consistency

### DIFF
--- a/examples/ballot/src/main.rs
+++ b/examples/ballot/src/main.rs
@@ -1,5 +1,5 @@
-use map_vec::Map;
-use oasis_std::{Address, Context}; // Provides a Map-like API but with smaller constant factors.
+use map_vec::Map; // Provides a Map-like API but with smaller constant factors.
+use oasis_std::{Address, Context};
 
 // Each service definition contains a struct that derives `Service`.
 // This struct represents the service's persistent state.

--- a/examples/ballot/src/main.rs
+++ b/examples/ballot/src/main.rs
@@ -1,10 +1,10 @@
 use map_vec::Map;
-use oasis_std::{Address, Context, Service}; // Provides a Map-like API but with smaller constant factors.
+use oasis_std::{Address, Context}; // Provides a Map-like API but with smaller constant factors.
 
 // Each service definition contains a struct that derives `Service`.
 // This struct represents the service's persistent state.
 // Changes to the state will be persisted across service invocations.
-#[derive(Service)]
+#[derive(oasis_std::Service)]
 pub struct Ballot {
     description: String,
     candidates: Vec<String>,

--- a/examples/erc20/src/main.rs
+++ b/examples/erc20/src/main.rs
@@ -2,7 +2,7 @@
 extern crate serde;
 
 use map_vec::{map::Entry, Map, Set};
-use oasis_std::{Address, Context, Event, Service};
+use oasis_std::{Address, Context, Event};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -27,7 +27,7 @@ pub enum Error {
     RequestExceedsAllowance { amount: u64, allowance: u64 },
 }
 
-#[derive(Service, Default)]
+#[derive(oasis_std::Service, Default)]
 pub struct ERC20Token {
     total_supply: u64,
     owner: Address,

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -2,7 +2,7 @@
 extern crate serde;
 
 use map_vec::{map::Entry, Map};
-use oasis_std::{Context, Service};
+use oasis_std::Context;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -12,7 +12,7 @@ pub enum Error {
     DuplicateEntry,
 }
 
-#[derive(Service)]
+#[derive(oasis_std::Service)]
 pub struct HelloWorld {
     helloworlds: Map<String, String>,
 }

--- a/examples/messaging/src/main.rs
+++ b/examples/messaging/src/main.rs
@@ -2,12 +2,12 @@
 extern crate serde; // Provides `Serialize` and `Deserialize`.
 
 use map_vec::{Map, Set};
-use oasis_std::{Address, Context, Event, Service};
+use oasis_std::{Address, Context, Event};
 
 pub type UserId = Address;
 pub type PostId = u32;
 
-#[derive(Service)]
+#[derive(oasis_std::Service)]
 pub struct MessageBoard {
     /// The administrators of this message board.
     /// Administrators can add and remove users.

--- a/examples/sealed-auctions/src/main.rs
+++ b/examples/sealed-auctions/src/main.rs
@@ -7,11 +7,11 @@ pub mod types;
 use map_vec::{map::Entry, Map, Set};
 
 use chrono::Utc;
-use oasis_std::{Context, Event, Service};
+use oasis_std::{Context, Event};
 
 use crate::types::*;
 
-#[derive(Service, Default)]
+#[derive(oasis_std::Service, Default)]
 pub struct AuctionMarket {
     /// The item counter
     item_counter: u64,


### PR DESCRIPTION
Don't `use oasis_std::Service` for consistency reasons with our tutorials.