### PR TITLE
Adding extern crate oasis_test to erc20

### DIFF
--- a/examples/erc20/src/main.rs
+++ b/examples/erc20/src/main.rs
@@ -224,6 +224,8 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
+    extern crate oasis_test;
+
     use super::*;
     use oasis_std::{Address, Context};
 


### PR DESCRIPTION
Added `extern crate oasis-test` to the `test` mod.