### PR TITLE
create local binding for borrow

### DIFF
--- a/oasis-build/src/gen/imports.rs
+++ b/oasis-build/src/gen/imports.rs
@@ -67,6 +67,8 @@ pub fn build(
 
             #[macro_use]
             extern crate serde;
+            
+            use std::borrow::Borrow;
 
             #(#def_tys)*
 


### PR DESCRIPTION
Quick fix for resolving:

```
error[E0599]: no method named `borrow` found for type `u64` in the current scope
  --> xcc/xcc-a/service/target/wasm32-wasi/release/build/oasis_imports/xcc_b-47dfe7bfc759a372.rs:27:32
   |
27 |         let payload: _ = &(num.borrow(),);
   |                                ^^^^^^
   |
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope, perhaps add a `use` for it:
   |
5  | use std::borrow::Borrow;
   |
```