### PR TITLE
Fix event log format in WASI backend

### DIFF
--- a/oasis-std/src/backend/wasi.rs
+++ b/oasis-std/src/backend/wasi.rs
@@ -153,5 +153,6 @@ pub fn emit(topics: &[&[u8]], data: &[u8]) {
             .unwrap();
         f_log.write_all(topic).unwrap();
     }
+    f_log.write_all(&(data.len() as u32).to_le_bytes());
     f_log.write_all(data).unwrap();
 }


### PR DESCRIPTION
The newest version of BCFS expects [length_data](https://github.com/oasislabs/oasis-rs/blob/master/bcfs/src/bcfs.rs#L617) for the event log format. This updates the WASI backend to produce the correct format.